### PR TITLE
fix: improve RAG recency ranking and ingestion text cleaning

### DIFF
--- a/backend/app/api/routes/router.py
+++ b/backend/app/api/routes/router.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-from app.rag.pipeline import run_rag_pipeline, DEFAULT_GENERATION_MODEL
-from app.rag.retriever import DEFAULT_SCORE_THRESHOLD, DEFAULT_TOP_K
+from backend.app.rag.pipeline import run_rag_pipeline, DEFAULT_GENERATION_MODEL
+from backend.app.rag.retriever import DEFAULT_SCORE_THRESHOLD, DEFAULT_TOP_K
 
 router = APIRouter()
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables or a .env file."""
 
     model_config = SettingsConfigDict(
-        env_file=".env",
+        env_file=str(_BACKEND_DIR / ".env"),
         env_file_encoding="utf-8",
         extra="ignore",
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,6 @@
 from fastapi import FastAPI
-from dotenv import load_dotenv
-from app.api.routes.router import router
 
-load_dotenv()
+from backend.app.api.routes.router import router
 
 app = FastAPI()
 app.include_router(router)

--- a/backend/app/rag/generator.py
+++ b/backend/app/rag/generator.py
@@ -22,6 +22,7 @@ Rules:
 - Do not speculate or infer beyond what the excerpts explicitly state.
 - Use clear, plain English; keep it concise.
 - If the question asks about a time period not covered by the Sources, say so explicitly.
+- When multiple sources address the same question, prefer the one with the most recent publication_date. Only cite an older source if the newer one does not contain the relevant information.
 
 Output format:
 - Answer: (your answer with inline citations like [Source 1])
@@ -44,14 +45,14 @@ def _build_context(hits: list[Any]) -> str:
         text = str(payload.get("text", "")).strip()
         source = payload.get("source_file", "unknown")
         chunk_index = payload.get("chunk_index", "unknown")
-        score = getattr(hit, "score", 0.0)
+        publication_date = payload.get("publication_date", "unknown")
         sections.append(
             "\n".join(
                 [
                     f"[Source {idx}]",
                     f"source_file: {source}",
+                    f"publication_date: {publication_date}",
                     f"chunk_index: {chunk_index}",
-                    f"score: {score:.4f}",
                     f"text: {text}",
                 ]
             )

--- a/backend/app/rag/retriever.py
+++ b/backend/app/rag/retriever.py
@@ -128,7 +128,7 @@ def _recency_boosted_hits(hits: list[Any], top_k: int) -> list[Any]:
     Returns:
         Re-ranked and trimmed list of hits.
     """
-    if len(hits) <= top_k:
+    if not hits:
         return hits
 
     dated_hits: list[tuple[Any, date]] = []

--- a/ingestion/chunk_and_embed.py
+++ b/ingestion/chunk_and_embed.py
@@ -237,6 +237,32 @@ def _delete_chunks_for_source(
     )
 
 
+def _clean_parsed_text(text: str) -> str:
+    """Normalize PDF-extracted text before chunking.
+
+    Removes PDF artifacts that pollute chunk embeddings:
+    - Form-feed characters (``\\x0c``) inserted at page boundaries
+    - BSP boilerplate page headers (``Classification: GENERAL`` /
+      ``Monetary Policy Report – <period> | <page>``)
+    - Collapses runs of more than two consecutive blank lines
+
+    Args:
+        text: Raw text from a parsed PDF .txt file.
+
+    Returns:
+        Cleaned text ready for token-based chunking.
+    """
+    # Page breaks → paragraph break
+    text = text.replace("\x0c", "\n\n")
+    # BSP page header: "Classification: GENERAL" line
+    text = re.sub(r"Classification:\s*GENERAL\s*\n", "", text)
+    # BSP page footer: "Monetary Policy Report – <period> | <N>"
+    text = re.sub(r"Monetary Policy Report\s*[–-][^\n]+\|\s*\d+\s*\n", "", text)
+    # Collapse 3+ blank lines to 2
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
 def _encode_for_chunking(text: str, enc: tiktoken.Encoding) -> list[int]:
     return enc.encode(text, disallowed_special=())
 
@@ -357,7 +383,7 @@ def main() -> int:
         _delete_chunks_for_source(qdrant, collection, path.name)
         doc_meta = manifest_by_source_file.get(path.name, {})
 
-        raw = path.read_text(encoding="utf-8")
+        raw = _clean_parsed_text(path.read_text(encoding="utf-8"))
         chunks = chunk_text_by_tokens(
             raw,
             enc,


### PR DESCRIPTION
- Fix retriever early exit that skipped recency sort when hits <= top_k
- Surface publication_date in LLM context; drop misleading raw score
- Add SYSTEM_PROMPT rule to prefer most recent source when content overlaps
- Add _clean_parsed_text() to strip \x0c form-feeds and BSP page headers (Classification: GENERAL / Monetary Policy Report page stamps) before chunking — fixes diluted embeddings in Feb2026/Dec2025/Aug2025 reports
- Fix import paths in router, main, and config to use backend.app.* prefix
- Fix Settings env_file to resolve relative to backend/ directory