### PR TITLE
feat: improve Q&A UI citations, source links, and cold-start notice

### DIFF
--- a/backend/app/rag/generator.py
+++ b/backend/app/rag/generator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 
@@ -12,22 +14,49 @@ You must answer questions based exclusively on the provided excerpts from offici
 
 You will be given:
 - A Question
-- A set of Sources, each with an excerpt and minimal metadata
+- A set of numbered Sources (e.g. [1], [2], …), each with an excerpt and minimal metadata
 
 Rules:
 - Use only the provided Sources. Do not use outside knowledge.
 - If the Sources do not contain enough information to answer, say exactly:
   "I could not find a reliable answer in the available BSP reports."
-- Every factual claim must be supported by at least one citation in the format [Source N].
+- Every factual claim must be cited inline using the bracketed number of the source, e.g. [1] or [2].
 - Do not speculate or infer beyond what the excerpts explicitly state.
 - Use clear, plain English; keep it concise.
 - If the question asks about a time period not covered by the Sources, say so explicitly.
 - When multiple sources address the same question, prefer the one with the most recent publication_date. Only cite an older source if the newer one does not contain the relevant information.
 
 Output format:
-- Answer: (your answer with inline citations like [Source 1])
-- Sources: (a list of each cited source, one per line)
+- Output ONLY the answer text with inline citations like [1].
+- Do NOT include a "Sources:" or "References:" list — that is handled separately.
 """
+
+
+def _load_manifest_lookup() -> dict[str, dict[str, str | None]]:
+    """Build a source_file → {url, period_label, title} lookup from manifest.json.
+
+    Returns:
+        A dict keyed by source txt filename (e.g. ``FullReport_2022_1.txt``).
+    """
+    manifest_path = Path(__file__).resolve().parents[3] / "ingestion" / "manifest.json"
+    if not manifest_path.is_file():
+        return {}
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    lookup: dict[str, dict[str, str | None]] = {}
+    for doc in data.get("documents", []):
+        url = doc.get("url")
+        if not isinstance(url, str):
+            continue
+        source_file = Path(url).stem + ".txt"
+        lookup[source_file] = {
+            "url": url,
+            "period_label": doc.get("period_label"),
+            "title": doc.get("title"),
+        }
+    return lookup
+
+
+_MANIFEST_LOOKUP: dict[str, dict[str, str | None]] = _load_manifest_lookup()
 
 
 def _build_context(hits: list[Any]) -> str:
@@ -49,7 +78,7 @@ def _build_context(hits: list[Any]) -> str:
         sections.append(
             "\n".join(
                 [
-                    f"[Source {idx}]",
+                    f"[{idx}]",
                     f"source_file: {source}",
                     f"publication_date: {publication_date}",
                     f"chunk_index: {chunk_index}",
@@ -72,12 +101,17 @@ def _build_sources(hits: list[Any]) -> list[dict[str, Any]]:
     sources: list[dict[str, Any]] = []
     for idx, hit in enumerate(hits, start=1):
         payload = hit.payload or {}
+        source_file = payload.get("source_file", "unknown")
+        meta = _MANIFEST_LOOKUP.get(str(source_file), {})
         sources.append(
             {
                 "source_id": idx,
-                "source_file": payload.get("source_file", "unknown"),
+                "source_file": source_file,
                 "chunk_index": payload.get("chunk_index", "unknown"),
                 "score": float(getattr(hit, "score", 0.0)),
+                "period_label": meta.get("period_label") or payload.get("period_label"),
+                "title": meta.get("title"),
+                "url": meta.get("url"),
             }
         )
     return sources

--- a/frontend/app/components/QAWidget.tsx
+++ b/frontend/app/components/QAWidget.tsx
@@ -7,6 +7,9 @@ type Source = {
   source_file: string;
   chunk_index: number;
   score: number;
+  period_label: string | null;
+  title: string | null;
+  url: string | null;
 };
 
 type QueryResponse = {
@@ -16,13 +19,47 @@ type QueryResponse = {
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
+const DOCS_URL = "https://github.com/cedricconol/bspQA#readme";
+
+/** Strip any trailing "Sources:" block the LLM might still emit. */
+function stripSourcesBlock(text: string): string {
+  return text.replace(/\n{0,2}Sources:\s*[\s\S]*$/i, "").trimEnd();
+}
+
+/** Render answer text, turning [N] into styled superscript spans. */
+function AnswerText({ text }: { text: string }) {
+  const parts = text.split(/(\[\d+\])/g);
+  return (
+    <p className="text-sm leading-7 text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap">
+      {parts.map((part, i) => {
+        const match = part.match(/^\[(\d+)\]$/);
+        if (match) {
+          return (
+            <sup key={i} className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+              [{match[1]}]
+            </sup>
+          );
+        }
+        return part;
+      })}
+    </p>
+  );
+}
+
+/** Format a source's display label as "Monetary Policy Report <Period>". */
+function sourceLabel(source: Source): string {
+  if (source.title) return source.title;
+  if (source.period_label) return `Monetary Policy Report ${source.period_label}`;
+  return source.source_file;
+}
+
 export default function QAWidget() {
   const [query, setQuery] = useState("");
   const [result, setResult] = useState<QueryResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
     if (!query.trim()) return;
 
@@ -55,14 +92,29 @@ export default function QAWidget() {
 
   return (
     <div className="w-full max-w-3xl mx-auto px-4 py-12 flex flex-col gap-8">
+      {/* Cold-start notice */}
+      <div className="rounded-md border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40 px-4 py-2.5 text-xs text-amber-700 dark:text-amber-400">
+        Your first query each session may take 30–60 seconds while the server wakes up.
+      </div>
+
       {/* Header */}
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
-          BSP Monetary Policy Q&amp;A
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-          Ask questions grounded in official BSP monetary policy and inflation reports.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+            BSP Monetary Policy Q&amp;A
+          </h1>
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            Ask questions grounded in official BSP monetary policy reports.
+          </p>
+        </div>
+        <a
+          href={DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 mt-1 text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
+        >
+          Docs ↗
+        </a>
       </div>
 
       {/* Query form */}
@@ -109,9 +161,7 @@ export default function QAWidget() {
             <p className="text-xs font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-3">
               Answer
             </p>
-            <p className="text-sm leading-7 text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap">
-              {result.answer}
-            </p>
+            <AnswerText text={stripSourcesBlock(result.answer)} />
           </div>
 
           {/* Sources */}
@@ -124,19 +174,25 @@ export default function QAWidget() {
                 {result.sources.map((source) => (
                   <div
                     key={source.source_id}
-                    className="flex items-start gap-3 rounded-lg border border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 px-4 py-3"
+                    className="flex items-center gap-3 rounded-lg border border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 px-4 py-3"
                   >
-                    <span className="mt-0.5 shrink-0 text-xs font-mono font-semibold text-zinc-400 dark:text-zinc-500">
+                    <span className="shrink-0 text-xs font-mono font-semibold text-zinc-400 dark:text-zinc-500">
                       [{source.source_id}]
                     </span>
-                    <div className="flex flex-col gap-0.5 min-w-0">
+                    {source.url ? (
+                      <a
+                        href={source.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm font-medium text-blue-600 dark:text-blue-400 underline underline-offset-2 hover:text-blue-800 dark:hover:text-blue-300 truncate"
+                      >
+                        {sourceLabel(source)}
+                      </a>
+                    ) : (
                       <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300 truncate">
-                        {source.source_file}
+                        {sourceLabel(source)}
                       </span>
-                      <span className="text-xs text-zinc-400 dark:text-zinc-500">
-                        chunk {source.chunk_index} · score {source.score.toFixed(3)}
-                      </span>
-                    </div>
+                    )}
                   </div>
                 ))}
               </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "BSP Monetary Policy Q&A",
-  description: "Ask questions grounded in official BSP monetary policy and inflation reports.",
+  description: "Ask questions grounded in official BSP monetary policy reports.",
 };
 
 export default function RootLayout({

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -48,16 +48,17 @@ def test_run_rag_pipeline_generates_answer_from_retrieved_hits(monkeypatch) -> N
     )
 
     assert result["answer"] == "Answer: Inflation eased. [Source 1]"
-    assert result["sources"] == [
-        {
-            "source_id": 1,
-            "source_file": "FullReport_December2025.txt",
-            "chunk_index": 12,
-            "score": 0.9876,
-        }
-    ]
+    assert len(result["sources"]) == 1
+    src = result["sources"][0]
+    assert src["source_id"] == 1
+    assert src["source_file"] == "FullReport_December2025.txt"
+    assert src["chunk_index"] == 12
+    assert src["score"] == 0.9876
+    assert src["period_label"] == "December 2025"
+    assert src["title"] == "Monetary Policy Report December 2025"
+    assert "FullReport_December2025.pdf" in (src["url"] or "")
     assert len(calls) == 1
     assert calls[0]["model"] == pipeline.DEFAULT_GENERATION_MODEL
     assert calls[0]["instructions"] == pipeline.SYSTEM_PROMPT
     assert "Question:\nDid inflation ease?" in calls[0]["input"]
-    assert "[Source 1]" in calls[0]["input"]
+    assert "[1]" in calls[0]["input"]


### PR DESCRIPTION
- Answer citations now use [N] format rendered as superscripts
- Sources list shows document title as a hyperlink to the PDF
- Backend enriches source response with url, period_label, title from manifest
- Add Docs link in header pointing to GitHub README
- Add cold-start warning for first-session Render spin-up delay