### PR TITLE
feat: add RAG eval system with LLM-as-judge scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ __marimo__/
 
 # ingestion data
 ingestion/data/
+
+# eval results
+results/

--- a/evals/EVALS.md
+++ b/evals/EVALS.md
@@ -1,0 +1,219 @@
+# bspQA Evaluation Report
+
+This document describes the evaluation methodology, terminology, and results for the bspQA RAG pipeline. Its purpose is to establish a measurable baseline and track performance improvements over time.
+
+---
+
+## Table of Contents
+
+1. [What Are Evals?](#what-are-evals)
+2. [Terminology](#terminology)
+3. [Eval Set](#eval-set)
+4. [How Scoring Works](#how-scoring-works)
+5. [How to Run](#how-to-run)
+6. [Results](#results)
+7. [Interpretation](#interpretation)
+8. [Next Steps](#next-steps)
+
+---
+
+## What Are Evals?
+
+Evals (evaluations) are structured tests that measure how well the RAG pipeline answers questions. Unlike unit tests that check code correctness, evals measure **output quality** — does the system retrieve the right information, does it answer the question, and does it stay faithful to its sources?
+
+Each eval run produces a scored summary across a fixed set of questions, making it possible to compare performance across different pipeline configurations over time.
+
+---
+
+## Terminology
+
+| Term | Definition |
+|---|---|
+| **RAG** | Retrieval-Augmented Generation. A pattern where a system retrieves relevant document chunks from a knowledge base and feeds them to an LLM to generate a grounded answer. |
+| **Chunk** | A fixed-length segment of text extracted from a source document. This pipeline uses 512-token chunks with 64-token overlap. |
+| **Embedding** | A numerical vector representation of text used to measure semantic similarity. The pipeline uses OpenAI's `text-embedding-3-small` model. |
+| **Vector search** | Finding the most semantically similar chunks to a query by comparing embedding vectors. The pipeline uses Qdrant as the vector database. |
+| **Recency bias** | This pipeline applies a recency boost (`RECENCY_WEIGHT = 0.85`) that re-ranks retrieved chunks to favor more recently published reports. High values strongly de-prioritize older documents. |
+| **LLM-as-judge** | Using a language model (here, `gpt-4o-mini`) to score another model's output for quality attributes like faithfulness and relevance. Scores are elicited as structured JSON. |
+| **Faithfulness** | Whether every factual claim in the generated answer is directly supported by the retrieved source excerpts. A faithfulness of 1.0 means nothing was hallucinated or inferred beyond what the sources say. |
+| **Relevance** | Whether the generated answer actually addresses the question that was asked. A relevance of 1.0 means the answer is directly and completely on-topic. |
+| **Source recall** | How much overlap exists between the documents the pipeline retrieved and the documents expected to contain the answer. Computed as Jaccard similarity: `|retrieved ∩ expected| / |retrieved ∪ expected|`. A low score means the pipeline found related-sounding chunks from the wrong reports. |
+| **Abstention accuracy** | For questions that are outside the scope of the corpus (adversarial cases), this measures whether the pipeline correctly responded with "I could not find a reliable answer" instead of hallucinating an answer. |
+| **No-answer rate** | The fraction of all questions where the pipeline returned the fallback message "I could not find a reliable answer in the available BSP reports." Includes both correct abstentions (adversarial questions) and incorrect abstentions (legitimate questions it failed to answer). |
+| **Jaccard similarity** | `|A ∩ B| / |A ∪ B|` — the ratio of shared items to total unique items between two sets. Used here to score source overlap: 1.0 is a perfect match, 0.0 is no overlap. |
+
+---
+
+## Eval Set
+
+The eval set contains **15 questions** across four categories, designed to stress-test different aspects of the pipeline. Questions span BSP Monetary Policy Reports from Q1 2022 to December 2024.
+
+| ID | Category | Difficulty | Question (abbreviated) |
+|---|---|---|---|
+| eval-001 | Single-doc | Easy | BSP baseline inflation forecast for 2022 as of Q1 2022 |
+| eval-002 | Single-doc | Easy | BSP overnight RRP policy rate at the Q1 2022 report |
+| eval-003 | Single-doc | Easy | BSP official core inflation figure for January 2023 |
+| eval-004 | Single-doc | Medium | Target RRP rate as of February 2024 and whether it changed |
+| eval-005 | Single-doc | Medium | Baseline inflation forecast for 2025 in the December 2024 report |
+| eval-006 | Multi-doc | Medium | How BSP's inflation outlook changed from Q1 2022 to Q1 2023 |
+| eval-007 | Multi-doc | Hard | RRP policy rate evolution from 2022 to end-2024 |
+| eval-008 | Multi-doc | Hard | Trend in reserve requirement ratio (RRR) from 2022 to 2024 |
+| eval-009 | Multi-doc | Medium | Oil price influence on inflation outlook: Q3 2022 vs Q4 2023 |
+| eval-010 | Rationale | Hard | Factors behind the 50 bps rate hike in November 2022 |
+| eval-011 | Rationale | Hard | Conditions that prompted the rate cut in August 2024 |
+| eval-012 | Rationale | Medium | Factors behind holding the rate at 6.50% in H1 2024 |
+| eval-013 | Adversarial | Hard | BSP's stance on cryptocurrency / Bitcoin (not in corpus) |
+| eval-014 | Adversarial | Hard | BSP Monetary Board decisions in March 2027 (future date) |
+| eval-015 | Adversarial | Hard | BSP vs ECB policy comparison (ECB not covered in corpus) |
+
+**Category definitions:**
+
+- **Single-doc** — The answer is contained entirely within one BSP report. Tests basic retrieval precision.
+- **Multi-doc** — The answer requires synthesizing information across multiple reports. Tests the pipeline's ability to surface the right documents for a time-range query.
+- **Rationale** — The question asks *why* the BSP made a decision. Tests whether the pipeline retrieves policy reasoning, not just rate figures.
+- **Adversarial** — The question asks about something outside the corpus. The correct behavior is to decline to answer rather than hallucinate.
+
+Full question text and `expected_sources` are in [`eval_set.json`](eval_set.json).
+
+---
+
+## How Scoring Works
+
+Each question is run through the pipeline and scored on four metrics:
+
+### Faithfulness (LLM-as-judge, 0.0–1.0)
+The judge model is shown the pipeline's answer alongside the raw text of retrieved chunks. It rates whether every factual claim in the answer is explicitly supported by those chunks. A score of 1.0 means the answer contains no hallucinations or unsupported inferences. Scored only for non-adversarial cases.
+
+### Relevance (LLM-as-judge, 0.0–1.0)
+The judge model is shown the question and the answer. It rates how directly and completely the answer addresses the question. A "I could not find..." response for a legitimate question scores 0.0.
+
+### Source Recall (Deterministic, 0.0–1.0)
+Computed as Jaccard similarity between the filenames of retrieved chunks and the expected source files from `eval_set.json`. This measures whether the pipeline is looking in the right documents, independent of answer quality. For adversarial cases, retrieval always happens at the Qdrant level before the LLM decides to abstain — so source recall for adversarial questions is always 0.0 by design and should be disregarded; use `abstention_accuracy` instead.
+
+### Abstention Accuracy (Adversarial cases only, 0.0–1.0)
+For the three adversarial questions, this binary score records whether the pipeline correctly returned the "I could not find a reliable answer" message rather than generating an answer.
+
+### Judge model
+All LLM-as-judge calls use `gpt-4o-mini` with `temperature=0` for determinism. The judge prompt requests a JSON response `{"score": float, "reason": str}` to avoid free-form variance.
+
+---
+
+## How to Run
+
+From the repo root with environment variables set (requires `OPENAI_API_KEY`, `QDRANT_CLUSTER_ENDPOINT`, `QDRANT_API_KEY`, `QDRANT_COLLECTION_NAME`):
+
+```bash
+# Run with default settings — saves to results/run_<TIMESTAMP>.json
+uv run python evals/run_evals.py
+
+# Verbose per-question logging
+uv run python evals/run_evals.py --log-level DEBUG
+
+# Save to a named file
+uv run python evals/run_evals.py --output results/my_run.json
+
+# Use a more capable judge model for higher-fidelity scores
+uv run python evals/run_evals.py --judge-model gpt-4o
+```
+
+Results are saved to `results/` (gitignored). The terminal prints a summary table; the JSON file contains per-question breakdowns including the full answer and retrieved source files.
+
+---
+
+## Results
+
+### Run 1 — Baseline
+
+**Timestamp:** 2026-04-29T03:35:39 UTC  
+**Pipeline:** VectorRAG (Qdrant + `text-embedding-3-small` + `gpt-4o-mini`, `RECENCY_WEIGHT=0.85`, `top_k=15`)  
+**Judge model:** `gpt-4o-mini`  
+**Eval set version:** 1.0 (15 questions)
+
+#### Summary
+
+| Metric | VectorRAG |
+|---|---|
+| **Faithfulness** | 0.667 |
+| **Relevance** | 0.567 |
+| **Source recall** | 0.146 |
+| **Abstention accuracy** | 1.000 |
+| **No-answer rate** | 0.400 |
+| **Avg latency (ms)** | 10,971 |
+
+#### Per-Question Breakdown
+
+| ID | Category | Faithfulness | Relevance | Source Recall | Abstained? | Latency (ms) |
+|---|---|---|---|---|---|---|
+| eval-001 | single_doc | 0.0 | 0.0 | 0.000 | — | 8,295 |
+| eval-002 | single_doc | 1.0 | 0.5 | 0.000 | — | 12,347 |
+| eval-003 | single_doc | 0.0 | 0.0 | 0.000 | — | 8,552 |
+| eval-004 | single_doc | 1.0 | 1.0 | 0.143 | — | 8,979 |
+| eval-005 | single_doc | 1.0 | 1.0 | 0.333 | — | 8,696 |
+| eval-006 | multi_doc | 1.0 | 1.0 | 0.143 | — | 16,989 |
+| eval-007 | multi_doc | 1.0 | 1.0 | 0.667 | — | 28,460 |
+| eval-008 | multi_doc | 0.0 | 0.0 | 0.222 | — | 10,572 |
+| eval-009 | multi_doc | 1.0 | 1.0 | 0.000 | — | 8,254 |
+| eval-010 | rationale | 1.0 | 1.0 | 0.200 | — | 8,195 |
+| eval-011 | rationale | 0.5 | 1.0 | 0.143 | — | 17,479 |
+| eval-012 | rationale | 0.5 | 1.0 | 0.333 | — | 6,540 |
+| eval-013 | adversarial | — | 0.0 | — | ✅ Yes | 10,132 |
+| eval-014 | adversarial | — | 0.0 | — | ✅ Yes | 5,449 |
+| eval-015 | adversarial | — | 0.0 | — | ✅ Yes | 5,619 |
+
+*Faithfulness and source recall marked `—` for adversarial cases; relevance is 0.0 for correct abstentions as expected.*
+
+---
+
+## Interpretation
+
+### What worked well
+
+**Abstention is perfect (1.0).** All three adversarial questions — cryptocurrency regulation, a future Monetary Board meeting, and ECB comparisons — were correctly declined. The LLM respected its system prompt and did not hallucinate answers for out-of-scope topics.
+
+**Faithfulness is solid when the pipeline answers.** Of the 12 non-adversarial questions where the pipeline produced an answer, 7 scored 1.0 on faithfulness and none scored below 0.5. When the pipeline retrieves chunks and generates a response, it stays grounded in its sources.
+
+**eval-007 (RRP rate evolution 2022–2024) is the strongest result.** Despite spanning 6 source documents, the pipeline surfaced 4 of the 6 expected reports (source recall: 0.67) and produced a factually grounded, well-structured answer.
+
+---
+
+### What needs improvement
+
+**Recency bias is causing 3 unexpected non-answers (eval-001, eval-003, eval-008).** These are legitimate questions about 2022 and 2023 data that the pipeline should be able to answer. The root cause is `RECENCY_WEIGHT = 0.85` in [`backend/app/rag/retriever.py`](../backend/app/rag/retriever.py) — the re-ranking step so strongly favors recent documents that chunks from 2022 reports are pushed below the score threshold entirely, leaving the LLM with no usable context.
+
+- **eval-001** (Q1 2022 inflation forecast): retrieved 15 chunks, all from 2024–2025 reports
+- **eval-003** (January 2023 core inflation): same pattern — retrieved only 2024–2025 chunks  
+- **eval-008** (RRR trend 2022–2024): retrieved chunks partially covering 2023 but not 2022
+
+**Source recall is low overall (0.146).** Even on questions the pipeline answers correctly, it typically retrieves the right answer from the wrong report (e.g., a later report that references an earlier decision). This means citations are often inaccurate even when answers are factually correct, which degrades user trust.
+
+**eval-002 relevance is only 0.5.** The pipeline gave the RRP rate from July 2022 (after a mid-year hike) rather than the rate that was current *at the time of the Q1 2022 report* (February 2022). The answer was faithful to its retrieved chunks but answered the wrong time slice — a temporal precision problem.
+
+**eval-009 source recall is 0.0.** The question asked about Q3 2022 and Q4 2023 oil price impacts. The pipeline retrieved only 2024 and early 2023 reports and synthesized an answer that was plausible but drawn from the wrong periods. High relevance (1.0) and faithfulness (1.0) masked this retrieval failure.
+
+**No-answer rate of 0.40 is too high.** Only 3 of the 6 no-answers are correct (the adversarial cases). The other 3 represent retrieval failures on legitimate historical questions.
+
+---
+
+## Next Steps
+
+Listed in priority order based on the results above.
+
+### 1. Reduce or make recency weight configurable
+**Impact:** Fixes the 3 unexpected no-answers; likely improves source recall significantly.  
+**Change:** Lower `RECENCY_WEIGHT` in [`backend/app/rag/retriever.py`](../backend/app/rag/retriever.py) from `0.85` toward `0.3–0.5`, or expose it as a parameter so callers can opt out of recency re-ranking for historical queries.
+
+### 2. Investigate chunk coverage for 2022 reports
+**Impact:** Ensures older documents are actually indexed with sufficient coverage.  
+**Change:** Verify that `FullReport_2022_1.txt` and `FullReport_2023_1.txt` are in the Qdrant collection with a reasonable number of chunks. Run a direct Qdrant query filtered to those source files and confirm they return results before attributing the miss purely to recency reranking.
+
+### 3. Add date-range metadata filtering to the API
+**Impact:** Allows queries like "as of Q1 2022" to explicitly restrict retrieval to documents from that period, bypassing the recency re-ranking problem for time-anchored questions.  
+**Change:** Detect temporal anchors in the query (e.g., "as of Q1 2022", "in November 2022") and automatically apply `publication_date_from`/`publication_date_to` filters, which are already supported by the retriever.
+
+### 4. Re-run evals after recency weight change
+**Expected outcome:** No-answer rate drops from 0.40 to ~0.20 (only adversarial), source recall improves from 0.146 to 0.30+, relevance improves from 0.567 to 0.80+.  
+**Command:** `uv run python evals/run_evals.py --output results/run_recency_tuned.json`
+
+### 5. Add reference answers to high-value eval cases
+**Impact:** Enables reference-based faithfulness scoring, which is more precise than reference-free LLM-as-judge for factual claims (e.g., specific rate figures and dates).  
+**Change:** Fill in `reference_answer` fields in `eval_set.json` for eval-001 through eval-005 using the actual BSP report text.

--- a/evals/eval_set.json
+++ b/evals/eval_set.json
@@ -1,0 +1,137 @@
+{
+  "version": "1.0",
+  "description": "bspQA eval set — 15 BSP Monetary Policy Report Q&A cases",
+  "cases": [
+    {
+      "id": "eval-001",
+      "category": "single_doc",
+      "difficulty": "easy",
+      "question": "What was the BSP's baseline inflation forecast for 2022 as of Q1 2022?",
+      "expected_sources": ["FullReport_2022_1.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-002",
+      "category": "single_doc",
+      "difficulty": "easy",
+      "question": "What was the BSP's overnight reverse repurchase (RRP) policy rate at the time of the Q1 2022 Monetary Policy Report?",
+      "expected_sources": ["FullReport_2022_1.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-003",
+      "category": "single_doc",
+      "difficulty": "easy",
+      "question": "What was the BSP's official core inflation figure for January 2023?",
+      "expected_sources": ["FullReport_2023_1.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-004",
+      "category": "single_doc",
+      "difficulty": "medium",
+      "question": "What was the target RRP rate as of the February 2024 Monetary Policy Report, and had it changed since the prior Monetary Board meeting?",
+      "expected_sources": ["FullReport_February2024.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-005",
+      "category": "single_doc",
+      "difficulty": "medium",
+      "question": "What was the baseline inflation forecast for 2025 published in the December 2024 Monetary Policy Report?",
+      "expected_sources": ["FullReport_December2024.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-006",
+      "category": "multi_doc",
+      "difficulty": "medium",
+      "question": "How did the BSP's near-term inflation outlook change from Q1 2022 to Q1 2023?",
+      "expected_sources": ["FullReport_2022_1.txt", "FullReport_2023_1.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-007",
+      "category": "multi_doc",
+      "difficulty": "hard",
+      "question": "How did the BSP's overnight RRP policy rate evolve from 2022 to end-2024, and what were the major turning points?",
+      "expected_sources": [
+        "FullReport_2022_1.txt",
+        "FullReport_2022_4.txt",
+        "FullReport_2023_1.txt",
+        "FullReport_February2024.txt",
+        "FullReport_August2024.txt",
+        "FullReport_December2024.txt"
+      ],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-008",
+      "category": "multi_doc",
+      "difficulty": "hard",
+      "question": "What was the trend in the BSP's reserve requirement ratio (RRR) from 2022 to 2024, and what was the stated rationale for any changes?",
+      "expected_sources": [
+        "FullReport_2022_1.txt",
+        "FullReport_2023_1.txt",
+        "FullReport_December2024.txt"
+      ],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-009",
+      "category": "multi_doc",
+      "difficulty": "medium",
+      "question": "How did global oil price developments influence the BSP's inflation outlook differently in Q3 2022 versus Q4 2023?",
+      "expected_sources": ["FullReport_2022_3.txt", "FullReport_2023_4.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-010",
+      "category": "rationale",
+      "difficulty": "hard",
+      "question": "What were the primary factors that led the BSP's Monetary Board to raise the RRP rate by 50 basis points in November 2022?",
+      "expected_sources": ["FullReport_2022_4.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-011",
+      "category": "rationale",
+      "difficulty": "hard",
+      "question": "What economic and inflation conditions prompted the BSP to begin cutting its policy rate in August 2024?",
+      "expected_sources": ["FullReport_August2024.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-012",
+      "category": "rationale",
+      "difficulty": "medium",
+      "question": "What factors led the BSP to keep the policy rate unchanged at 6.50 percent through the first half of 2024?",
+      "expected_sources": ["FullReport_February2024.txt", "FullReport_May2024.txt"],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-013",
+      "category": "adversarial",
+      "difficulty": "hard",
+      "question": "What is the BSP's official stance on cryptocurrency regulation and Bitcoin as of 2024?",
+      "expected_sources": [],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-014",
+      "category": "adversarial",
+      "difficulty": "hard",
+      "question": "What were the key decisions made at the BSP Monetary Board meeting in March 2027?",
+      "expected_sources": [],
+      "reference_answer": null
+    },
+    {
+      "id": "eval-015",
+      "category": "adversarial",
+      "difficulty": "hard",
+      "question": "How do BSP monetary policy decisions compare with those of the European Central Bank over the period 2022 to 2024?",
+      "expected_sources": [],
+      "reference_answer": null
+    }
+  ]
+}

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -1,0 +1,452 @@
+"""CLI eval runner for bspQA RAG pipeline evaluation.
+
+Usage:
+    uv run python evals/run_evals.py
+    uv run python evals/run_evals.py --output results/my_run.json
+    uv run python evals/run_evals.py --log-level DEBUG
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure repo root is on sys.path so `backend.*` and `evals.*` resolve correctly
+# regardless of which directory the script is invoked from.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import argparse
+import json
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+NO_ANSWER_SENTINEL = "I could not find a reliable answer"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline abstractions
+# ---------------------------------------------------------------------------
+
+
+class BasePipeline(ABC):
+    """Abstract interface for a RAG pipeline under evaluation."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable pipeline name used in reports."""
+
+    @abstractmethod
+    def query(self, question: str) -> dict[str, Any]:
+        """Run the pipeline on a question and return a standardized result dict.
+
+        Args:
+            question: The natural language question to answer.
+
+        Returns:
+            A dict with keys:
+                ``answer`` (str): The generated answer text.
+                ``sources`` (list[dict]): Each element must have a ``source_file`` key.
+                ``chunks_text`` (str): Raw concatenated chunk text used for generation,
+                    needed for faithfulness scoring.
+        """
+
+
+class VectorRAGPipeline(BasePipeline):
+    """Wraps the current Qdrant-based RAG pipeline.
+
+    Calls retrieve_chunks() directly to capture raw chunk text for faithfulness
+    scoring, then delegates to run_rag_pipeline() for answer generation.
+    """
+
+    def __init__(self) -> None:
+        _load_dotenv()
+
+    @property
+    def name(self) -> str:
+        return "VectorRAG"
+
+    def query(self, question: str) -> dict[str, Any]:
+        """Query the vector RAG pipeline and return answer + raw chunk text.
+
+        Args:
+            question: The natural language question to answer.
+
+        Returns:
+            Standardized result dict with answer, sources, and chunks_text.
+        """
+        from backend.app.rag.pipeline import run_rag_pipeline
+        from backend.app.rag.retriever import retrieve_chunks
+
+        hits = retrieve_chunks(query=question)
+        chunks_text = "\n\n".join(
+            f"[{i+1}] {hit.payload.get('source_file','')}: {hit.payload.get('text','')}"
+            for i, hit in enumerate(hits)
+            if hit.payload
+        )
+        result = run_rag_pipeline(question)
+        return {
+            "answer": result.get("answer", ""),
+            "sources": result.get("sources", []),
+            "chunks_text": chunks_text,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EvalCase:
+    """A single eval question with ground-truth metadata."""
+
+    id: str
+    question: str
+    expected_sources: list[str]
+    reference_answer: str | None
+    difficulty: str
+    category: str
+
+
+@dataclass
+class EvalResult:
+    """Scored result for one pipeline run on one eval case."""
+
+    eval_id: str
+    pipeline: str
+    question: str
+    answer: str
+    retrieved_source_files: list[str]
+    expected_sources: list[str]
+    faithfulness: float | None
+    relevance: float
+    source_recall: float
+    correctly_abstained: bool | None
+    latency_ms: float
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Core eval logic
+# ---------------------------------------------------------------------------
+
+
+def _is_no_answer(answer: str) -> bool:
+    return NO_ANSWER_SENTINEL.lower() in answer.lower()
+
+
+def run_single_eval(
+    case: EvalCase,
+    pipeline: BasePipeline,
+    openai_client: Any,
+    *,
+    judge_model: str = "gpt-4o-mini",
+) -> EvalResult:
+    """Execute one pipeline query on one eval case and return scored results.
+
+    Args:
+        case: The eval case to run.
+        pipeline: The pipeline implementation to query.
+        openai_client: OpenAI client instance for LLM-as-judge calls.
+        judge_model: Model name for LLM-as-judge scoring.
+
+    Returns:
+        A fully populated EvalResult.
+    """
+    from scoring import score_faithfulness, score_relevance, score_source_recall
+
+    answer = ""
+    sources: list[dict[str, Any]] = []
+    chunks_text = ""
+    error: str | None = None
+
+    start = time.monotonic()
+    try:
+        result = pipeline.query(case.question)
+        answer = result.get("answer", "")
+        sources = result.get("sources", [])
+        chunks_text = result.get("chunks_text", "")
+    except Exception as exc:
+        _logger.error("eval.pipeline_error", exc_info=True, extra={"eval_id": case.id})
+        error = str(exc)
+    latency_ms = round((time.monotonic() - start) * 1000, 1)
+
+    retrieved_source_files = [s.get("source_file", "") for s in sources if s.get("source_file")]
+
+    is_adversarial = len(case.expected_sources) == 0
+    correctly_abstained: bool | None = _is_no_answer(answer) if is_adversarial else None
+
+    source_recall = score_source_recall(retrieved_source_files, case.expected_sources)
+    relevance = score_relevance(case.question, answer, openai_client, model=judge_model)
+
+    faithfulness: float | None = None
+    if not is_adversarial:
+        if chunks_text:
+            faithfulness = score_faithfulness(answer, chunks_text, openai_client, model=judge_model)
+        else:
+            faithfulness = 0.0
+
+    return EvalResult(
+        eval_id=case.id,
+        pipeline=pipeline.name,
+        question=case.question,
+        answer=answer,
+        retrieved_source_files=retrieved_source_files,
+        expected_sources=case.expected_sources,
+        faithfulness=faithfulness,
+        relevance=relevance,
+        source_recall=source_recall,
+        correctly_abstained=correctly_abstained,
+        latency_ms=latency_ms,
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _build_summary(results: list[EvalResult]) -> dict[str, dict[str, float]]:
+    """Aggregate per-result scores into per-pipeline summary statistics.
+
+    Args:
+        results: All EvalResult objects from a run.
+
+    Returns:
+        Dict mapping pipeline name to metric name to aggregated float value.
+    """
+    from collections import defaultdict
+
+    buckets: dict[str, list[EvalResult]] = defaultdict(list)
+    for r in results:
+        buckets[r.pipeline].append(r)
+
+    summary: dict[str, dict[str, float]] = {}
+    for pipeline_name, pipeline_results in buckets.items():
+        faith_scores = [r.faithfulness for r in pipeline_results if r.faithfulness is not None]
+        abstention_cases = [r for r in pipeline_results if r.correctly_abstained is not None]
+
+        summary[pipeline_name] = {
+            "faithfulness": round(sum(faith_scores) / len(faith_scores), 3) if faith_scores else 0.0,
+            "relevance": round(
+                sum(r.relevance for r in pipeline_results) / len(pipeline_results), 3
+            ),
+            "source_recall": round(
+                sum(r.source_recall for r in pipeline_results) / len(pipeline_results), 3
+            ),
+            "abstention_accuracy": round(
+                sum(1 for r in abstention_cases if r.correctly_abstained) / len(abstention_cases),
+                3,
+            ) if abstention_cases else 0.0,
+            "no_answer_rate": round(
+                sum(1 for r in pipeline_results if _is_no_answer(r.answer)) / len(pipeline_results),
+                3,
+            ),
+            "avg_latency_ms": round(
+                sum(r.latency_ms for r in pipeline_results) / len(pipeline_results), 1
+            ),
+        }
+    return summary
+
+
+def _print_comparison_table(summary: dict[str, dict[str, float]]) -> None:
+    """Print a formatted side-by-side comparison table to stdout.
+
+    Args:
+        summary: Output of _build_summary().
+    """
+    pipelines = list(summary.keys())
+    metrics = [
+        "faithfulness",
+        "relevance",
+        "source_recall",
+        "abstention_accuracy",
+        "no_answer_rate",
+        "avg_latency_ms",
+    ]
+
+    col_w = max(20, max(len(p) for p in pipelines) + 2)
+    label_w = 22
+
+    header = f"{'Metric':<{label_w}}" + "".join(f"{p:<{col_w}}" for p in pipelines)
+    print()
+    print(header)
+    print("-" * (label_w + col_w * len(pipelines)))
+    for metric in metrics:
+        row = f"{metric:<{label_w}}"
+        for p in pipelines:
+            val = summary.get(p, {}).get(metric, 0.0)
+            row += f"{val:<{col_w}}"
+        print(row)
+    print()
+
+
+def _save_results(
+    results: list[EvalResult],
+    summary: dict[str, dict[str, float]],
+    output_path: Path,
+) -> None:
+    """Serialize results and summary to a JSON file.
+
+    Args:
+        results: Per-question eval results.
+        summary: Per-pipeline aggregated metrics.
+        output_path: Destination path; parent directories are created if needed.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "run_timestamp": datetime.now(timezone.utc).isoformat(),
+        "summary": summary,
+        "per_question": [asdict(r) for r in results],
+    }
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _logger.info("results.saved", extra={"path": str(output_path)})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_dotenv() -> None:
+    """Load .env files from repo root and backend/ into the environment."""
+    try:
+        from dotenv import load_dotenv
+
+        root = Path(__file__).resolve().parents[1]
+        load_dotenv(root / ".env")
+        load_dotenv(root / "backend" / ".env")
+    except ImportError:
+        pass
+
+
+def _load_eval_cases(path: Path) -> list[EvalCase]:
+    """Load and parse eval cases from a JSON file.
+
+    Args:
+        path: Path to eval_set.json.
+
+    Returns:
+        List of EvalCase instances.
+
+    Raises:
+        SystemExit: If the file cannot be read or parsed.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return [EvalCase(**c) for c in data["cases"]]
+    except (FileNotFoundError, KeyError, TypeError) as exc:
+        _logger.error("eval_set.load_failed: %s", exc)
+        sys.exit(1)
+
+
+def _build_openai_client() -> Any:
+    """Construct an OpenAI client using the OPENAI_API_KEY environment variable.
+
+    Returns:
+        An authenticated OpenAI client instance.
+
+    Raises:
+        SystemExit: If OPENAI_API_KEY is not set.
+    """
+    import os
+
+    from openai import OpenAI
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        _logger.error("OPENAI_API_KEY is not set. Cannot run LLM-as-judge scoring.")
+        sys.exit(1)
+    return OpenAI(api_key=api_key)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Parse CLI args, run evals, print comparison table, and save results."""
+    parser = argparse.ArgumentParser(
+        description="Run bspQA eval suite and compare pipeline performance.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Output JSON path. Defaults to results/run_<TIMESTAMP>.json.",
+    )
+    parser.add_argument(
+        "--eval-set",
+        default=str(Path(__file__).parent / "eval_set.json"),
+        metavar="PATH",
+        help="Path to eval_set.json.",
+    )
+    parser.add_argument(
+        "--judge-model",
+        default="gpt-4o-mini",
+        help="OpenAI model for LLM-as-judge scoring.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    _load_dotenv()
+
+    pipelines: list[BasePipeline] = [VectorRAGPipeline()]
+
+    cases = _load_eval_cases(Path(args.eval_set))
+    _logger.info("Loaded %d eval cases", len(cases))
+
+    openai_client = _build_openai_client()
+
+    all_results: list[EvalResult] = []
+    for pipeline in pipelines:
+        _logger.info("Running pipeline: %s", pipeline.name)
+        for case in cases:
+            _logger.info("  [%s] %s", case.id, case.question[:70])
+            result = run_single_eval(
+                case,
+                pipeline,
+                openai_client,
+                judge_model=args.judge_model,
+            )
+            all_results.append(result)
+            _logger.debug(
+                "  scores: faithfulness=%s relevance=%.2f recall=%.2f latency=%.0fms",
+                f"{result.faithfulness:.2f}" if result.faithfulness is not None else "n/a",
+                result.relevance,
+                result.source_recall,
+                result.latency_ms,
+            )
+
+    summary = _build_summary(all_results)
+    _print_comparison_table(summary)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_path = Path(args.output) if args.output else Path("results") / f"run_{ts}.json"
+    _save_results(all_results, summary, output_path)
+    print(f"Results saved to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/scoring.py
+++ b/evals/scoring.py
@@ -1,0 +1,168 @@
+"""LLM-as-judge scoring helpers and deterministic metrics for bspQA evals."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+_FAITHFULNESS_SYSTEM = """\
+You are a strict faithfulness evaluator for a RAG system.
+
+Given:
+- SOURCES: the only text excerpts the system was allowed to use
+- ANSWER: the system-generated answer
+
+Rate how well every factual claim in ANSWER is grounded in SOURCES.
+- 1.0: all claims are directly and explicitly supported by SOURCES
+- 0.5: most claims are supported, but some are inferred or partially unsupported
+- 0.0: major claims are unsupported, fabricated, or contradict SOURCES
+
+Respond with ONLY valid JSON, no markdown: {"score": <0.0-1.0>, "reason": "<one sentence>"}\
+"""
+
+_RELEVANCE_SYSTEM = """\
+You are a relevance evaluator for a Q&A system.
+
+Given a QUESTION and an ANSWER, rate how directly and completely the ANSWER addresses the QUESTION.
+- 1.0: fully and directly answers the question
+- 0.5: partially answers, or addresses only part of the question
+- 0.0: does not address the question, or answers a different question
+
+Respond with ONLY valid JSON, no markdown: {"score": <0.0-1.0>, "reason": "<one sentence>"}\
+"""
+
+
+def _parse_judge_response(raw: str) -> float:
+    """Extract the score float from a raw LLM judge response string.
+
+    Tries strict JSON parse first, then falls back to regex for malformed outputs.
+
+    Args:
+        raw: Raw string content from the LLM response.
+
+    Returns:
+        A float in [0.0, 1.0]. Returns 0.0 and logs a warning on total parse failure.
+    """
+    try:
+        data = json.loads(raw.strip())
+        return float(data["score"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        pass
+
+    match = re.search(r'"score"\s*:\s*([0-9]*\.?[0-9]+)', raw)
+    if match:
+        try:
+            return min(1.0, max(0.0, float(match.group(1))))
+        except ValueError:
+            pass
+
+    _logger.warning("judge.parse_failed", extra={"raw_response": raw[:200]})
+    return 0.0
+
+
+def score_faithfulness(
+    answer: str,
+    sources_text: str,
+    client: Any,
+    *,
+    model: str = "gpt-4o-mini",
+) -> float:
+    """Score whether every factual claim in answer is supported by sources_text.
+
+    Args:
+        answer: The RAG system's generated answer string.
+        sources_text: Raw source excerpts the system retrieved (concatenated chunk text).
+        client: An authenticated OpenAI client instance.
+        model: OpenAI model name to use for judging.
+
+    Returns:
+        A float in [0.0, 1.0]. Returns 0.0 on parse failure after logging a warning.
+    """
+    prompt = f"SOURCES:\n{sources_text}\n\nANSWER:\n{answer}"
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": _FAITHFULNESS_SYSTEM},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.0,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception:
+        _logger.exception("judge.faithfulness_api_error")
+        return 0.0
+    return _parse_judge_response(raw)
+
+
+def score_relevance(
+    question: str,
+    answer: str,
+    client: Any,
+    *,
+    model: str = "gpt-4o-mini",
+) -> float:
+    """Score whether answer addresses the core intent of question.
+
+    Args:
+        question: The original eval question string.
+        answer: The RAG system's generated answer string.
+        client: An authenticated OpenAI client instance.
+        model: OpenAI model name to use for judging.
+
+    Returns:
+        A float in [0.0, 1.0]. Returns 0.0 on parse failure after logging a warning.
+    """
+    prompt = f"QUESTION:\n{question}\n\nANSWER:\n{answer}"
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": _RELEVANCE_SYSTEM},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.0,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception:
+        _logger.exception("judge.relevance_api_error")
+        return 0.0
+    return _parse_judge_response(raw)
+
+
+def score_source_recall(
+    retrieved_sources: list[str],
+    expected_sources: list[str],
+) -> float:
+    """Compute Jaccard similarity of retrieved source filenames vs. expected.
+
+    Filenames are normalized by stripping the .txt extension before comparison.
+
+    For adversarial cases where expected_sources is empty:
+    - Returns 1.0 if retrieved_sources is also empty (correct abstention).
+    - Returns 0.0 if retrieved_sources is non-empty (should have abstained).
+
+    Args:
+        retrieved_sources: List of source_file values from the pipeline result.
+        expected_sources: List of expected source_file values from eval_set.json.
+
+    Returns:
+        Jaccard similarity in [0.0, 1.0].
+    """
+
+    def _stem(name: str) -> str:
+        return name.removesuffix(".txt").strip()
+
+    retrieved = {_stem(s) for s in retrieved_sources if s}
+    expected = {_stem(s) for s in expected_sources if s}
+
+    if not expected:
+        return 1.0 if not retrieved else 0.0
+
+    intersection = retrieved & expected
+    union = retrieved | expected
+    return len(intersection) / len(union) if union else 1.0


### PR DESCRIPTION
- Add 15-question eval set covering single-doc, multi-doc, rationale, and adversarial categories across BSP Monetary Policy Reports
- Add scoring.py with faithfulness, relevance, and source recall metrics
- Add run_evals.py CLI runner with VectorRAGPipeline abstraction
- Add EVALS.md documenting methodology, terminology, baseline results, and next steps
- Gitignore results/ output directory

Baseline run (2026-04-29): faithfulness 0.667, relevance 0.567, source_recall 0.146, abstention_accuracy 1.0